### PR TITLE
MLA Publication Date should include day of month

### DIFF
--- a/modern-language-association.csl
+++ b/modern-language-association.csl
@@ -206,7 +206,7 @@
         <date variable="issued" form="numeric" date-parts="year"/>
       </if>
       <else-if type="article-journal article-magazine" match="any">
-        <date variable="issued" form="text" date-parts="year-month"/>
+        <date variable="issued" form="text" date-parts="year-month-day"/>
       </else-if>
       <else-if type="speech" match="none">
         <date variable="issued" form="text"/>


### PR DESCRIPTION
Apologies in advance if this is not the correct process for contributing. I'm normally a software engineer, not an English major. 

In referencing the MLA 9th edition style guide, it appears as though the publication date should include the day of the month in the date format. See these examples on Purdue OWL: https://owl.purdue.edu/owl/research_and_citation/mla_style/mla_formatting_and_style_guide/mla_works_cited_periodicals.html